### PR TITLE
Add workaround for grub bug in Debian 10.4

### DIFF
--- a/debian/debian_swraid_lvm_luks.md
+++ b/debian/debian_swraid_lvm_luks.md
@@ -117,10 +117,12 @@ Now we mount and copy our installation back on the new lvs:
 
 ### Some changes to your existing linux installation
 Lets mount some special filesystems for chroot usage:
+- `mkdir -p /mnt/run/udev`
 - `mount /dev/md0 /mnt/boot`
 - `mount --bind /dev /mnt/dev`
 - `mount --bind /sys /mnt/sys`
 - `mount --bind /proc /mnt/proc`
+- `mount --bind /run/udev /mnt/run/udev`
 - `chroot /mnt`
 
 To let the system know there is a new crypto device we need to edit the cryptab(/etc/crypttab):
@@ -144,7 +146,7 @@ To be sure the network interface is coming up:
 Time for our first reboot.. fingers crossed!
 
 - `exit`
-- `umount /mnt/boot /mnt/home /mnt/var/log /mnt/proc /mnt/sys /mnt/dev`
+- `umount /mnt/boot /mnt/home /mnt/var/log /mnt/proc /mnt/sys /mnt/dev /mnt/run/udev`
 - `umount /mnt`
 - `sync`
 - `reboot`

--- a/debian/debian_swraid_lvm_luks.md
+++ b/debian/debian_swraid_lvm_luks.md
@@ -89,7 +89,7 @@ We have now to edit your vg0 backup:
 ```
 vg0 {
    ...
-   physical_volumnes {
+   physical_volumes {
       id = "UUID aquired with the blkid command"
       device = "/dev/mapper/cryptroot"
       ...


### PR DESCRIPTION
Using the update-grub command in chroot causes performance problems in Debian Buster. The update takes several hours instead of the usual few seconds. Mounting "/run/udev" into the chroot can workaround this issue and speeds up the process significantly. Further details can be found here: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=925146 