### PR TITLE
Missed dropbear-initramfs in the list of packages to install

### DIFF
--- a/debian/debian_swraid_lvm_luks.md
+++ b/debian/debian_swraid_lvm_luks.md
@@ -43,7 +43,7 @@ PART lvm vg0 all
 
 - connect via ssh-key you choosed before for the rescue image (attention to the .ssh/known_hosts file..)
 - install busybox and dropbear
-- `apt update && apt install busybox dropbear lvm2`
+- `apt update && apt install busybox dropbear lvm2 dropbear-initramfs`
 - Edit your `/etc/initramfs-tools/initramfs.conf` and set `BUSYBOX=y`
 - Create a new ssh key for unlocking your encrypted volumes when it is rebooting
 - `ssh-keygen -t rsa -b 4096 -f .ssh/dropbear`


### PR DESCRIPTION
If dropbear-initramfs is not installed the server won't boot. All other instructions in this repo include this package.